### PR TITLE
Compile issue fix, update transport

### DIFF
--- a/EthereumWrapperDemo/EthereumWrapperDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EthereumWrapperDemo/EthereumWrapperDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LedgerHQ/hw-transport-ios-ble",
       "state" : {
-        "revision" : "935a680a0f84a4e468c2f9baf8f949246c66884c",
-        "version" : "1.0.0"
+        "revision" : "4df8fff21c1738a1dff4d2ee19175dd3263d6c5f",
+        "version" : "1.0.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LedgerHQ/ios-ble-wrapper",
       "state" : {
-        "revision" : "61029276d7ad03b9add7641c9510fb99d711f09d",
-        "version" : "1.0.0"
+        "revision" : "39ee35508caf3408416eec8a566008c4532d1640",
+        "version" : "1.0.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LedgerHQ/hw-transport-ios-ble",
       "state" : {
-        "revision" : "935a680a0f84a4e468c2f9baf8f949246c66884c",
-        "version" : "1.0.0"
+        "revision" : "4df8fff21c1738a1dff4d2ee19175dd3263d6c5f",
+        "version" : "1.0.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LedgerHQ/ios-ble-wrapper",
       "state" : {
-        "revision" : "61029276d7ad03b9add7641c9510fb99d711f09d",
-        "version" : "1.0.0"
+        "revision" : "39ee35508caf3408416eec8a566008c4532d1640",
+        "version" : "1.0.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,21 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "bluejay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/harrisonf-ledger/bluejay",
-      "state" : {
-        "branch" : "multiplatform",
-        "revision" : "20eac767b8404f6e97eba341395bd0c7f3f3d2d6"
-      }
-    },
-    {
       "identity" : "hw-transport-ios-ble",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LedgerHQ/hw-transport-ios-ble",
       "state" : {
-        "branch" : "disable-background-error",
-        "revision" : "f7ae73aed42601f72a94576ae176612178591d40"
+        "revision" : "935a680a0f84a4e468c2f9baf8f949246c66884c",
+        "version" : "1.0.0"
       }
     },
     {
@@ -23,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LedgerHQ/ios-ble-wrapper",
       "state" : {
-        "branch" : "main",
-        "revision" : "6584aa05ae107644067a23c210f3ff9c62809192"
+        "revision" : "61029276d7ad03b9add7641c9510fb99d711f09d",
+        "version" : "1.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["EthWrapper"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/LedgerHQ/ios-ble-wrapper", exact: "1.0.0"),
+        .package(url: "https://github.com/LedgerHQ/ios-ble-wrapper", exact: "1.0.1"),
     ],
     targets: [
         .target(

--- a/Sources/EthWrapper/EthWrapper.swift
+++ b/Sources/EthWrapper/EthWrapper.swift
@@ -93,7 +93,7 @@ public class EthWrapper: BleWrapper {
     
     public func signTransaction(path: String, rawTxHex: String, resolution: LedgerEthTransactionResolution?, success: @escaping DictionaryResponse, failure: @escaping ErrorResponse) {
         var arguments: [Any] = [path, rawTxHex]
-        if let resolution {
+        if let resolution = resolution {
             arguments.append(resolution.toDictionary())
         }
         invokeMethod(.signTransaction, arguments: arguments, success: { resolve in


### PR DESCRIPTION
There's a bug in the Ledger Connect build pipeline that's stopping us from using Xcode 14. This PR reverts to the older `if let` syntax to allow running the build job with Xcode 13. 

This also updates to the latest version of the BLE transport libraries.